### PR TITLE
Add 'streaming', 'streamingMaybe' variants of 'pipeline', 'pipelineMaybe'

### DIFF
--- a/riak.cabal
+++ b/riak.cabal
@@ -131,6 +131,8 @@ library
                 text                          == 1.2.*,
                 time                          >= 1.4.2     && < 1.9,
                 vector                        >= 0.10.12.3 && < 0.13,
+                unliftio                      >= 0.2.7,
+                unliftio-core                 >= 0.1.1,
                 unordered-containers          >= 0.2.5
 
 

--- a/riak.cabal
+++ b/riak.cabal
@@ -121,6 +121,7 @@ library
                 monad-control                 >= 1.0.0.4  && < 1.1,
                 network                       >= 2.3,
                 resource-pool                 == 0.2.*,
+                pipes,
                 protocol-buffers              >= 2.1.4    && < 2.5,
                 pureMD5,
                 random,

--- a/riak.cabal
+++ b/riak.cabal
@@ -121,7 +121,7 @@ library
                 monad-control                 >= 1.0.0.4  && < 1.1,
                 network                       >= 2.3,
                 resource-pool                 == 0.2.*,
-                pipes,
+                pipes                         >= 4        && < 4.4,
                 protocol-buffers              >= 2.1.4    && < 2.5,
                 pureMD5,
                 random,

--- a/src/Network/Riak/Connection.hs
+++ b/src/Network/Riak/Connection.hs
@@ -25,6 +25,8 @@ module Network.Riak.Connection
     , pipeline
     , pipelineMaybe
     , pipeline_
+    , streaming
+    , streamingMaybe
     ) where
 
 import Network.Riak.Connection.Internal

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,3 +3,6 @@ packages:
 - '.'
 - protobuf/
 - protobuf-lens/
+extra-deps:
+- unliftio-0.2.7.0
+- unliftio-core-0.1.1.0


### PR DESCRIPTION
Hi there, I added streaming variants of `pipeline` / `pipelineMaybe`. 

Example type signatures:

```haskell
streaming 
  :: Exchange req resp 
  => Connection 
  -> Producer' req IO () 
  -> Producer' resp IO ()

-- Compare to:
pipeline
  :: Exchange req resp
  => Connection
  -> [req]
  -> IO [resp]
```

The benefit is the caller can immediately start consuming the responses without having to wait for the whole list to come back.

One downside: I felt like I had to commit to a specific streaming type (I chose to use `pipes`). I couldn't figure out how to make a streaming-backend-agnostic function.