### PR TITLE
Ghc84

### DIFF
--- a/src/Network/Riak/CRDT.hs
+++ b/src/Network/Riak/CRDT.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {- | module:    Network.Riak.CRDT
      copyright: (c) 2016 Sentenai
      author:    Antonio Nikishaev <me@lelf.lu>
@@ -43,7 +44,9 @@ module Network.Riak.CRDT (module Network.Riak.CRDT.Types,
 import Data.Default.Class
 import qualified Data.Map as M
 import Data.Proxy
+#if __GLASGOW_HASKELL__ < 804
 import Data.Semigroup
+#endif
 import qualified Data.Set as S
 import Network.Riak.CRDT.Ops
 import Network.Riak.CRDT.Riak

--- a/src/Network/Riak/CRDT/Ops.hs
+++ b/src/Network/Riak/CRDT/Ops.hs
@@ -22,7 +22,8 @@ import qualified Network.Riak.Protocol.MapUpdate as PBMap
 import qualified Network.Riak.Protocol.MapUpdate.FlagOp as PBFlag
 
 import           Data.ByteString.Lazy (ByteString)
-import           Data.Monoid
+import           Data.Monoid (Monoid(mempty, mappend))
+import           Data.Semigroup (Semigroup((<>)))
 import qualified Data.Sequence as Seq
 import qualified Data.Set as S
 import           Network.Riak.CRDT.Types
@@ -42,6 +43,9 @@ counterOpPB ops = PB.CounterOp (Just i)
 data SetOpsComb = SetOpsComb { setAdds :: S.Set ByteString,
                                setRemoves :: S.Set ByteString }
              deriving (Show)
+
+instance Semigroup SetOpsComb where
+    (SetOpsComb a b) <> (SetOpsComb x y) = SetOpsComb (a<>x) (b<>y)
 
 instance Monoid SetOpsComb where
     mempty = SetOpsComb mempty mempty

--- a/src/Network/Riak/CRDT/Ops.hs
+++ b/src/Network/Riak/CRDT/Ops.hs
@@ -22,7 +22,6 @@ import qualified Network.Riak.Protocol.MapUpdate as PBMap
 import qualified Network.Riak.Protocol.MapUpdate.FlagOp as PBFlag
 
 import           Data.ByteString.Lazy (ByteString)
-import           Data.Monoid (Monoid(mempty, mappend))
 import           Data.Semigroup (Semigroup((<>)))
 import qualified Data.Sequence as Seq
 import qualified Data.Set as S

--- a/src/Network/Riak/CRDT/Types.hs
+++ b/src/Network/Riak/CRDT/Types.hs
@@ -278,6 +278,9 @@ instance Default Counter where
 -- >>> CounterInc 1
 data CounterOp = CounterInc !Count deriving (Eq,Show)
 
+instance Semigroup CounterOp where
+    CounterInc x <> CounterInc y = CounterInc . getSum $ Sum x <> Sum y
+
 instance Monoid CounterOp where
     mempty = CounterInc 0
     CounterInc x `mappend` CounterInc y = CounterInc . getSum $ Sum x <> Sum y

--- a/src/Network/Riak/JSON.hs
+++ b/src/Network/Riak/JSON.hs
@@ -36,13 +36,14 @@ import Data.Aeson.Types (FromJSON(..), ToJSON(..))
 #if __GLASGOW_HASKELL__ < 710
 import Data.Monoid (Monoid)
 #endif
+import Data.Semigroup (Semigroup)
 import Data.Typeable (Typeable)
 import Network.Riak.Types.Internal
 import qualified Network.Riak.Value as V
 
 newtype JSON a = J {
       plain :: a -- ^ Unwrap a 'JSON'-wrapped value.
-    } deriving (Eq, Ord, Show, Read, Bounded, Typeable, Monoid)
+    } deriving (Eq, Ord, Show, Read, Bounded, Typeable, Semigroup, Monoid)
 
 -- | Wrap up a value so that it will be encoded and decoded as JSON
 -- when converted to/from 'Content'.

--- a/src/Network/Riak/Request.hs
+++ b/src/Network/Riak/Request.hs
@@ -56,7 +56,9 @@ module Network.Riak.Request
 import Control.Applicative ((<$>))
 #endif
 import qualified Data.ByteString.Char8 as B8
+#if __GLASGOW_HASKELL__ < 804
 import Data.Monoid
+#endif
 import Network.Riak.Protocol.BucketProps (BucketProps)
 import Network.Riak.Protocol.Content
 import Network.Riak.Protocol.GetClientIDRequest

--- a/src/Network/Riak/Resolvable/Internal.hs
+++ b/src/Network/Riak/Resolvable/Internal.hs
@@ -45,6 +45,7 @@ import Data.Maybe (isJust)
 #if __GLASGOW_HASKELL__ < 710
 import Data.Monoid (Monoid(mappend))
 #endif
+import Data.Semigroup (Semigroup)
 import Data.Typeable (Typeable)
 import Network.Riak.Debug (debugValues)
 import Network.Riak.Types.Internal hiding (MessageTag(..))
@@ -86,7 +87,7 @@ class (Show a) => Resolvable a where
 -- | A newtype wrapper that uses the 'mappend' method of a type's
 -- 'Monoid' instance to perform vector clock conflict resolution.
 newtype ResolvableMonoid a = RM { unRM :: a }
-    deriving (Eq, Ord, Read, Show, Typeable, Data, Monoid, FromJSON, ToJSON)
+    deriving (Eq, Ord, Read, Show, Typeable, Data, Semigroup, Monoid, FromJSON, ToJSON)
 
 instance (Show a, Monoid a) => Resolvable (ResolvableMonoid a) where
     resolve = mappend

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -15,7 +15,9 @@ import qualified Data.Set as S
 import qualified Data.Sequence as Seq
 import           Data.List.NonEmpty (NonEmpty(..))
 import           Data.Foldable (toList)
+#if __GLASGOW_HASKELL__ < 804
 import           Data.Semigroup
+#endif
 import           Data.Text (Text)
 import           Control.Concurrent (threadDelay)
 import           Control.Exception


### PR DESCRIPTION
Regarding Issue #105: Monoid needs Semigroup

This commit adds the required Semigroup instances, it compiles without warnings under GHC 7.10.3, GHC 8.2.2, and 8.4.1. As I could not run the test suite please ensure your usual tests run correctly before merging.

hope this helps, Nik