### PR TITLE
Bump deps

### DIFF
--- a/riak.cabal
+++ b/riak.cabal
@@ -101,7 +101,7 @@ library
                   Network.Riak.Tag
 
   build-depends:
-                aeson                         >= 0.8      && < 1.3,
+                aeson                         >= 0.8      && < 1.4,
                 async                         >= 2.0.0.0  && < 2.3,
                 attoparsec                    >= 0.12.1.6 && < 0.14,
                 base                          >= 3        && < 5,
@@ -113,7 +113,7 @@ library
                 data-default-class            >= 0.0.1,
                 deepseq                       >= 1.3,
                 enclosed-exceptions           >= 1.0.1.1  && <= 1.1,
-                exceptions                    >= 0.8.0.2  && <= 0.9,
+                exceptions                    >= 0.8.0.2  && < 0.11,
                 hashable                      >= 1.2.3,
                 transformers                  >= 0.3      && < 0.6,
                 transformers-base             == 0.4.*,


### PR DESCRIPTION
After this is merged, please consider adding back riak and riak-protobuf (I'm happy to do that for you) into the stackage snapshot, since LTS12 is going out soon https://www.stackage.org/blog/2018/06/upcoming-lts-12-ghc-8-4-3